### PR TITLE
Add an "Updated" field to existing stars when they are updated

### DIFF
--- a/commands/active.js
+++ b/commands/active.js
@@ -32,6 +32,7 @@ async function run({ interaction }) {
 
       releasedStars.forEach((star, index) => {
         const foundDate = new Date(star.foundAt);
+        const updatedDate = new Date(star.updatedAt);
 
         embed.addFields({
           name: `⭐ ${star.location}`,
@@ -39,7 +40,9 @@ async function run({ interaction }) {
                   Tier: ${star.tier}
                   Found ${formatDistanceToNow(foundDate, {
                     addSuffix: true,
-                  })} by <@${star.foundBy}>`,
+                  })} by <@${star.foundBy}>
+                  ${star.updatedAt ? 'Updated ' + formatDistanceToNow(updatedDate, { addSuffix: true, }) : ''}
+                  `,
         });
       });
       logger.info("/active");

--- a/commands/get-backups.js
+++ b/commands/get-backups.js
@@ -40,6 +40,7 @@ async function run({ interaction }) {
       backupStars.forEach((star, index) => {
         const foundDate = new Date(star.foundAt);
         const foundByThisUser = star.foundBy == interaction.user.id;
+        const updatedDate = new Date(star.updatedAt);
 
         embed.addFields({
           name: `🔒 ${star.location}`,
@@ -49,6 +50,7 @@ async function run({ interaction }) {
                   Found ${formatDistanceToNow(foundDate, {
                     addSuffix: true,
                   })} by <@${star.foundBy}>
+                  ${star.updatedAt ? 'Updated ' + formatDistanceToNow(updatedDate, { addSuffix: true, }) : ''}
                   `,
         });
       });

--- a/commands/hold.js
+++ b/commands/hold.js
@@ -37,7 +37,9 @@ const data = new SlashCommandBuilder()
       .setRequired(true)
   )
   .addStringOption((option) =>
-    option.setName("credit").setDescription("Credit for whoever found the star")
+    option
+      .setName("credit")
+      .setDescription("Credit for whoever found the star")
   );
 locations.forEach((loc) => {
   data.options[2].addChoices(loc);

--- a/commands/update-tier.js
+++ b/commands/update-tier.js
@@ -30,13 +30,14 @@ const data = new SlashCommandBuilder()
 async function run({ interaction }) {
   const world = interaction.options.get("world").value;
   const newTier = interaction.options.get("new-tier").value;
+  const updatedDate = new Date();
 
   const starsCollection = db.getStarsCollection();
 
   try {
     const update = await starsCollection.updateOne(
       { world },
-      { $set: { tier: newTier } }
+      { $set: { tier: newTier, updatedAt: updatedDate } }
     );
 
     if (update.modifiedCount === 1) {

--- a/schemas/ActiveStar.js
+++ b/schemas/ActiveStar.js
@@ -7,9 +7,10 @@ class ActiveStar extends Star {
     location,
     foundBy,
     foundAt = new Date(),
+    updatedAt = null,
     calledAt = new Date()
   ) {
-    super(world, tier, location, foundBy, foundAt);
+    super(world, tier, location, foundBy, foundAt, updatedAt);
 
     this.calledAt = calledAt;
   }

--- a/schemas/Star.js
+++ b/schemas/Star.js
@@ -5,6 +5,7 @@ class Star {
     location,
     foundBy,
     foundAt = new Date(),
+    updatedAt = null,
     calledAt = null,
     credit = foundBy
   ) {
@@ -13,6 +14,7 @@ class Star {
     this.location = location;
     this.foundBy = foundBy;
     this.foundAt = foundAt;
+    this.updatedAt = updatedAt;
     this.calledAt = calledAt;
     this.credit = credit;
   }

--- a/utils/update-tier.js
+++ b/utils/update-tier.js
@@ -11,7 +11,7 @@ updateStarTier = async (world, newTier) => {
     const starsCollection = db.getStarsCollection();
     const result = await starsCollection.updateOne(
       { world },
-      { $set: { tier: newTier } }
+      { $set: { tier: newTier, updatedAt: updatedDate } }
     );
     return "Success";
   } catch (error) {


### PR DESCRIPTION
When a star is updated with **/update**, the timestamp is saved. When **/active** or **/backups** is called, if there is an `updatedAt` timestamp, it will display it in the message.

![image](https://github.com/luisr96/discord-bot-starhunters/assets/22157813/aab67799-2579-4c0d-babd-d7281312e572)
