### PR TITLE
Reduce cron frequency and revert star saving logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,14 +57,14 @@ client.once("ready", () => {
   logger.info("Bot is online");
 
   autoCallStars(client);
-  // Every 1 minute
-  cron.schedule('*/1 * * * *', () => {
+  // Every 5 minutes
+  cron.schedule('*/5 * * * *', () => {
     logger.info('Running /call after 1 minute');
     autoCallStars(client);
   });
 
-  // Every 5 minutes
-  cron.schedule('*/5 * * * *', () => {
+  // Every 30 minutes
+  cron.schedule('*/30 * * * *', () => {
     logger.info('Running import-sm stars');
     autoImportSMStars();
   });

--- a/utils/save-star.js
+++ b/utils/save-star.js
@@ -15,8 +15,8 @@ saveStar = async (starToSave, interaction) => {
 
   const starExists = await getStarInWorld(starToSave.world);
 
-  // if the star already exists and is the same location
-  if (starExists && starExists.location === starToSave.location) {
+  // if the star already exists
+  if (starExists) {
     // save without changing foundAt
     delete starToSave.foundAt;
   }


### PR DESCRIPTION
I think the cron jobs is causing the bot to crash more often and reducing the frequency should help that.

The star saving logic was also overwriting stars when a Starminer's star conflicted with an already called star in the same world but different location (likely from the fuzzy location names not matching). This will prevent a star from being automatically replaced without explicitly being removed.